### PR TITLE
Updated RenderJob Offsets

### DIFF
--- a/offsets.hpp
+++ b/offsets.hpp
@@ -126,8 +126,8 @@ namespace offsets {
     inline constexpr uintptr_t ProximityPromptHoldDuraction = 0x140;
     inline constexpr uintptr_t ProximityPromptMaxActivationDistance = 0x148;
     inline constexpr uintptr_t ProximityPromptMaxObjectText = 0xF0;
-    inline constexpr uintptr_t RenderJobToDataModel = 0x1B0;
-    inline constexpr uintptr_t RenderJobToFakeDataModel = 0x38;
+    inline constexpr uintptr_t RenderJobToDataModel1 = 0x1D8; // FakeDataModel
+    inline constexpr uintptr_t RenderJobToDataModel2 = 0x1C0;
     inline constexpr uintptr_t RenderJobToRenderView = 0x218;
     inline constexpr uintptr_t RequireBypass = 0x8F8;
     inline constexpr uintptr_t RigType = 0x1C8;

--- a/offsets.hpp
+++ b/offsets.hpp
@@ -1,5 +1,5 @@
-// Roblox Version: ???
-// Byfron Version: ???
+// Roblox Version: version-80c7b8e578f241ff
+// Byfron Version: Hyperion7
 namespace offsets {
     inline constexpr uintptr_t Adornee = 0xD0;
     inline constexpr uintptr_t Anchored = 0x1AE;

--- a/offsets.json
+++ b/offsets.json
@@ -1,6 +1,6 @@
 {
   "RobloxVersion": "version-80c7b8e578f241ff",
-  "ByfronVersion": "???",
+  "ByfronVersion": "Hyperion7",
   "Adornee": "0xD0",
   "Anchored": "0x1AE",
   "AnchoredMask": "0x2",
@@ -126,8 +126,8 @@
   "ProximityPromptHoldDuraction": "0x140",
   "ProximityPromptMaxActivationDistance": "0x148",
   "ProximityPromptMaxObjectText": "0xF0",
-  "RenderJobToDataModel": "0x1B0",
-  "RenderJobToFakeDataModel": "0x38",
+  "RenderJobToDataModel1": "0x1D8",
+  "RenderJobToDataModel2": "0x1C0",
   "RenderJobToRenderView": "0x218",
   "RequireBypass": "0x8F8",
   "RigType": "0x1C8",


### PR DESCRIPTION
I've removed the `RenderJobToDataModel` as it doesn't seem to exist anymore (checked in reclass) and changed the method to get the datamodel from render_job from `render_job -> dm` to `render_job -> fakedm/rawdm -> dm` as there isn't any other apparent methods?

Also a minor change was the Hyperion Version & the missing Roblox Version from the .hpp file